### PR TITLE
fix(docs): Improve the api documentation with mosqlient package examples

### DIFF
--- a/mkdocs/docs/datastore/GET/climate.md
+++ b/mkdocs/docs/datastore/GET/climate.md
@@ -120,9 +120,9 @@ Below is a usable example of fetching data from the 3304557 (Rio de Janeiro) cit
 ```py
   from mosqlient import get_climate
 
-    # return a pd.DataFrame with the data 
-    df = get_climate(
-               start_date='2022-12-30', 
-               end_date = '2023-01-30',
-               geocode = 3304557)
+  # return a pd.DataFrame with the data 
+  df = get_climate(
+      start_date='2022-12-30', 
+      end_date = '2023-01-30',
+      geocode = 3304557)
 ```

--- a/mkdocs/docs/datastore/GET/climate.md
+++ b/mkdocs/docs/datastore/GET/climate.md
@@ -118,11 +118,11 @@ In the package, there is a function called `get_climate` that returns a pandas D
 
 Below is a usable example of fetching data from the 3304557 (Rio de Janeiro) city.
 ```py
-  from mosqlient import get_climate
+from mosqlient import get_climate
 
-  # return a pd.DataFrame with the data 
-  df = get_climate(
-      start_date='2022-12-30', 
-      end_date = '2023-01-30',
-      geocode = 3304557)
+# return a pd.DataFrame with the data 
+df = get_climate(
+    start_date='2022-12-30', 
+    end_date = '2023-01-30',
+    geocode = 3304557)
 ```

--- a/mkdocs/docs/datastore/GET/climate.md
+++ b/mkdocs/docs/datastore/GET/climate.md
@@ -109,3 +109,20 @@ Through this API endpoint, you can fetch several climate variables that have bee
 *The response's pagination contain information about the amount of items returned
 by the API call. These information can be used to navigate between the queried
 data by changing the `page` parameter on the URL. [See details](#details)
+
+## Example using the mosqlient package
+
+The mosqlient is a Python package created to facilitate the use of API. 
+
+In the package, there is a function called `get_climate` that returns a pandas DataFrame with the data. This function accepts as filters the parameters `start_date`, `end_date`, `geocode`, and `uf`, with the same types defined in the parameters table above. 
+
+Below is a usable example of fetching data from the 3304557 (Rio de Janeiro) city.
+```py
+  from mosqlient import get_climate
+
+    # return a pd.DataFrame with the data 
+    df = get_climate(
+               start_date='2022-12-30', 
+               end_date = '2023-01-30',
+               geocode = 3304557)
+```

--- a/mkdocs/docs/datastore/GET/infodengue.md
+++ b/mkdocs/docs/datastore/GET/infodengue.md
@@ -124,12 +124,12 @@ In the package, there is a function called `get_infodengue` that returns a panda
 
 Below is a usable example of fetching data from the `RJ` state.
 ```py
-    from mosqlient import get_infodengue
+from mosqlient import get_infodengue
 
-    # return a pd.DataFrame with the data 
-    df = get_infodengue(
-        start_date='2022-12-30', 
-        end_date = '2023-01-30', 
-        disease = 'dengue',
-        uf = 'RJ')
+# return a pd.DataFrame with the data 
+df = get_infodengue(
+    start_date='2022-12-30', 
+    end_date = '2023-01-30', 
+    disease = 'dengue',
+    uf = 'RJ')
 ```

--- a/mkdocs/docs/datastore/GET/infodengue.md
+++ b/mkdocs/docs/datastore/GET/infodengue.md
@@ -128,8 +128,8 @@ Below is a usable example of fetching data from the `RJ` state.
 
     # return a pd.DataFrame with the data 
     df = get_infodengue(
-               start_date='2022-12-30', 
-               end_date = '2023-01-30', 
-               disease = 'dengue',
-               uf = 'RJ')
+        start_date='2022-12-30', 
+        end_date = '2023-01-30', 
+        disease = 'dengue',
+        uf = 'RJ')
 ```

--- a/mkdocs/docs/datastore/GET/infodengue.md
+++ b/mkdocs/docs/datastore/GET/infodengue.md
@@ -114,3 +114,22 @@ For an example of API usage in Mosqlimate, please refer to [API Demo](https://ap
 *The response's pagination contains information about the amount of items returned
 by the API call. These information can be used to navigate between the queried
 data by changing the `page` parameter on the URL. [See details](#details)
+
+
+## Example using the mosqlient package
+
+The mosqlient is a Python package created to facilitate the use of API. 
+
+In the package, there is a function called `get_infodengue` that returns a pandas DataFrame with the data. This function accepts as filters the parameters `start_date`, `end_date`, `diasese`, `geocode`, and `uf`, with the same types defined in the parameters table above. 
+
+Below is a usable example of fetching data from the `RJ` state.
+```py
+    from mosqlient import get_infodengue
+
+    # return a pd.DataFrame with the data 
+    df = get_infodengue(
+               start_date='2022-12-30', 
+               end_date = '2023-01-30', 
+               disease = 'dengue',
+               uf = 'RJ')
+```

--- a/mkdocs/docs/registry/GET/models.md
+++ b/mkdocs/docs/registry/GET/models.md
@@ -140,3 +140,24 @@
       -H 'accept: application/json'
 
     ```
+
+## Examples using the mosqlient package
+
+The mosqlient is a Python package created to facilitate the use of API. 
+
+In the package, there is a function called `get_models` that returns a list of dictionaries with information about the models. This function accepts as filters all the parameters in the parameters table above except `page` and `per_page`. 
+
+Below is a usable example of fetching the models filtering by `implementation_language` and `author_name`.
+```py
+    from mosqlient import get_models
+
+    get_models(implementation_language = 'Python', author_name = 'Eduardo Correa Araujo')
+```
+
+Also, there is a specific function that filters the models by any parameter. This function is called `get_models_by_{parameter}`. The example below shows how it can be used to filter all the `dengue` models in the platform. 
+
+```py
+    from mosqlient import get_models_by_disease
+
+    get_models_by_disease(disease = 'dengue')
+```

--- a/mkdocs/docs/registry/GET/models.md
+++ b/mkdocs/docs/registry/GET/models.md
@@ -149,15 +149,16 @@ In the package, there is a function called `get_models` that returns a list of d
 
 Below is a usable example of fetching the models filtering by `implementation_language` and `author_name`.
 ```py
-    from mosqlient import get_models
+from mosqlient import get_models
 
-    get_models(implementation_language = 'Python', author_name = 'Eduardo Correa Araujo')
+get_models(implementation_language = 'Python', 
+          author_name = 'Eduardo Correa Araujo')
 ```
 
 Also, there is a specific function that filters the models by any parameter. This function is called `get_models_by_{parameter}`. The example below shows how it can be used to filter all the `dengue` models in the platform. 
 
 ```py
-    from mosqlient import get_models_by_disease
+from mosqlient import get_models_by_disease
 
-    get_models_by_disease(disease = 'dengue')
+get_models_by_disease(disease = 'dengue')
 ```

--- a/mkdocs/docs/registry/GET/predictions.md
+++ b/mkdocs/docs/registry/GET/predictions.md
@@ -143,43 +143,43 @@ In the package, there is a function called `get_predictions` that returns a list
 
 Below is a usable example of fetching the predictions filtering by `model_disease` and `model_ADM_level`.
 ```py
-    from mosqlient import get_predictions
+from mosqlient import get_predictions
 
-    get_predictions(model_disease = 'dengue', model_ADM_level = 2)
+get_predictions(model_disease = 'dengue', model_ADM_level = 2)
 ```
 
 Also, there is a specific function that filters the predictions by any parameter. This function is called `get_models_by_{parameter}`. The example below shows how it can be used to filter all the predictions from a specific model, referred to by his`model_id`, in the platform. Below is an example. 
 
 ```py
-    from mosqlient import get_predictions_by_model_id
+from mosqlient import get_predictions_by_model_id
 
-    get_predictions_by_model_id(model_id = 6)
+get_predictions_by_model_id(model_id = 6)
 ```
 
 The functions above return a list of dictionaries, each representing the metadata associated with a single prediction. To obtain a DataFrame from the JSON prediction, you can use the code below: 
 
 ```py 
-    from mosqlient import get_predictions_by_model_id
+from mosqlient import get_predictions_by_model_id
     
-    def transform_json_to_dataframe(res:dict) -> pd.DataFrame:
-      """
-      A function that transforms the prediction output from the API and transforms it in a DataFrame.
+def transform_json_to_dataframe(res:dict) -> pd.DataFrame:
+  """
+  A function that transforms the prediction output from the API and transforms it in a DataFrame.
 
-      Parameters:
-      rest (dict): Output of the  prediction's API.
+  Parameters:
+  rest (dict): Output of the  prediction's API.
 
-      Returns:
-      pd.DataFrame. 
-      """
+  Returns:
+  pd.DataFrame. 
+  """
 
-      json_struct = json.loads(res['prediction'])    
-      df = pd.json_normalize(json_struct)
-      df.dates = pd.to_datetime(df.dates)
+  json_struct = json.loads(res['prediction'])    
+  df = pd.json_normalize(json_struct)
+  df.dates = pd.to_datetime(df.dates)
 
-      return df
+  return df
     
 
-    preds = get_predictions_by_model_id(model_id = 6)
+preds = get_predictions_by_model_id(model_id = 6)
 
-    df_preds_0 = transform_json_to_dataframe(preds[0])
+df_preds_0 = transform_json_to_dataframe(preds[0])
 ```

--- a/mkdocs/docs/registry/GET/predictions.md
+++ b/mkdocs/docs/registry/GET/predictions.md
@@ -133,3 +133,53 @@
       'https://api.mosqlimate.org/api/registry/predictions/?start=2023-01-01&end=2023-02-01&page=1&per_page=50' \
       -H 'accept: application/json'
     ```
+
+
+## Examples using the mosqlient package
+
+The mosqlient is a Python package created to facilitate the use of API. 
+
+In the package, there is a function called `get_predictions` that returns a list of dictionaries with information about the predictions. This function accepts as filters all the parameters in the parameters table above except `page` and `per_page`. 
+
+Below is a usable example of fetching the predictions filtering by `model_disease` and `model_ADM_level`.
+```py
+    from mosqlient import get_predictions
+
+    get_predictions(model_disease = 'dengue', model_ADM_level = 2)
+```
+
+Also, there is a specific function that filters the predictions by any parameter. This function is called `get_models_by_{parameter}`. The example below shows how it can be used to filter all the predictions from a specific model, referred to by his`model_id`, in the platform. Below is an example. 
+
+```py
+    from mosqlient import get_predictions_by_model_id
+
+    get_predictions_by_model_id(model_id = 6)
+```
+
+The functions above return a list of dictionaries, each representing the metadata associated with a single prediction. To obtain a DataFrame from the JSON prediction, you can use the code below: 
+
+```py 
+    from mosqlient import get_predictions_by_model_id
+    
+    def transform_json_to_dataframe(res:dict) -> pd.DataFrame:
+      """
+      A function that transforms the prediction output from the API and transforms it in a DataFrame.
+
+      Parameters:
+      rest (dict): Output of the  prediction's API.
+
+      Returns:
+      pd.DataFrame. 
+      """
+
+      json_struct = json.loads(res['prediction'])    
+      df = pd.json_normalize(json_struct)
+      df.dates = pd.to_datetime(df.dates)
+
+      return df
+    
+
+    preds = get_predictions_by_model_id(model_id = 6)
+
+    df_preds_0 = transform_json_to_dataframe(preds[0])
+```

--- a/mkdocs/docs/registry/POST/models.md
+++ b/mkdocs/docs/registry/POST/models.md
@@ -155,3 +155,28 @@ POST requests require [User API Token](uid-key.md) to be called.
         "time_resolution": "week"
     }'
     ```
+
+## Examples using the mosqlient package
+
+The mosqlient is a Python package created to facilitate the use of API. 
+
+In the package, there is a function called `upload_model` that can be used to save the models in the platform. 
+
+Below is a usable example of the function.
+```py
+    from mosqlient import upload_model
+
+    upload_model(
+        name = "My Nowcasting Model",
+        description = "My Model description",
+        repository = "https://github.com/Mosqlimate-project/Data-platform",
+        implementation_language = "Python",
+        disease = "dengue",
+        temporal = False,
+        spatial = True,
+        categorical = False,
+        adm_level = 0, # National
+        time_resolution = "week",
+        api_key = "X-UID-Key"
+    )
+```

--- a/mkdocs/docs/registry/POST/models.md
+++ b/mkdocs/docs/registry/POST/models.md
@@ -164,19 +164,19 @@ In the package, there is a function called `upload_model` that can be used to sa
 
 Below is a usable example of the function.
 ```py
-    from mosqlient import upload_model
+from mosqlient import upload_model
 
-    upload_model(
-        name = "My Nowcasting Model",
-        description = "My Model description",
-        repository = "https://github.com/Mosqlimate-project/Data-platform",
-        implementation_language = "Python",
-        disease = "dengue",
-        temporal = False,
-        spatial = True,
-        categorical = False,
-        adm_level = 0, # National
-        time_resolution = "week",
-        api_key = "X-UID-Key"
+upload_model(
+    name = "My Nowcasting Model",
+    description = "My Model description",
+    repository = "https://github.com/Mosqlimate-project/Data-platform",
+    implementation_language = "Python",
+    disease = "dengue",
+    temporal = False,
+    spatial = True,
+    categorical = False,
+    adm_level = 0, # National
+    time_resolution = "week",
+    api_key = "X-UID-Key"
     )
 ```

--- a/mkdocs/docs/registry/POST/predictions.md
+++ b/mkdocs/docs/registry/POST/predictions.md
@@ -115,3 +115,28 @@ POST requests require [User API Token](uid-key.md) to be called.
       "prediction": {"prediction": "example"}
     }'   
     ```
+
+## Examples using the mosqlient package
+
+The mosqlient is a Python package created to facilitate the use of API. 
+
+In the package, there is a function called `upload_prediction` that can be used to send the predictions to the platform. 
+
+Below is a usable example of the function.
+```py
+    from mosqlient import upload_prediction
+
+    upload_prediction(
+        model_id = 0, # Check the ID in models list or profile
+        description = "My Prediction description",
+        commit = "3d1d2cd016fe38b6e7d517f724532de994d77618",
+        predict_date = "2023-10-31",
+        predict =  "json_str_prediction",
+        api_key = "X-UID-Key"
+    )
+```
+
+If you have a pandas DataFrame, called `df`, with the columns requested by the platform, that is: `dates`, `lower`, `preds`, `upper`, `adm_0`, `adm_1`, and `adm_2` you can transform it in the JSON string format accepted by the platform following the example below: 
+```py
+    df.to_json(orient = 'records', date_format = 'iso')
+```

--- a/mkdocs/docs/registry/POST/predictions.md
+++ b/mkdocs/docs/registry/POST/predictions.md
@@ -124,16 +124,16 @@ In the package, there is a function called `upload_prediction` that can be used 
 
 Below is a usable example of the function.
 ```py
-    from mosqlient import upload_prediction
+from mosqlient import upload_prediction
 
-    upload_prediction(
-        model_id = 0, # Check the ID in models list or profile
-        description = "My Prediction description",
-        commit = "3d1d2cd016fe38b6e7d517f724532de994d77618",
-        predict_date = "2023-10-31",
-        predict =  "json_str_prediction",
-        api_key = "X-UID-Key"
-    )
+upload_prediction(
+  model_id = 0, # Check the ID in models list or profile
+  description = "My Prediction description",
+  commit = "3d1d2cd016fe38b6e7d517f724532de994d77618",
+  predict_date = "2023-10-31",
+  predict =  "json_str_prediction",
+  api_key = "X-UID-Key"
+  )
 ```
 
 If you have a pandas DataFrame, called `df`, with the columns requested by the platform, that is: `dates`, `lower`, `preds`, `upper`, `adm_0`, `adm_1`, and `adm_2` you can transform it in the JSON string format accepted by the platform following the example below: 

--- a/mkdocs/docs/registry/POST/predictions.md
+++ b/mkdocs/docs/registry/POST/predictions.md
@@ -138,5 +138,5 @@ upload_prediction(
 
 If you have a pandas DataFrame, called `df`, with the columns requested by the platform, that is: `dates`, `lower`, `preds`, `upper`, `adm_0`, `adm_1`, and `adm_2` you can transform it in the JSON string format accepted by the platform following the example below: 
 ```py
-    df.to_json(orient = 'records', date_format = 'iso')
+df.to_json(orient = 'records', date_format = 'iso')
 ```


### PR DESCRIPTION
@fccoelho After talking to Lua, we decided that it would be interesting to keep the Python examples of how to use the platform using requests since it is the formal way. 

Below these examples, I added a section called `Examples using the mosqlient package, where I provide small examples of how the task discussed on the page can be done using the mosqlient Python package. 